### PR TITLE
Switch mirror auth to a GitHub App + add debug output

### DIFF
--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -39,7 +39,7 @@ jobs:
     # target mirror repository and replaces the old per-repo SSH deploy keys.
     - name: Generate push token for ${{ matrix.module_name }}
       id: app-token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: "4076510"
         private-key: ${{ secrets.DUNE_MIRRORER_CERT }}

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -30,29 +30,40 @@ jobs:
     needs: repos
     strategy:
       fail-fast: false
-      # each job gets "slug" and "url" and "module_name"
+      # each job gets "module_name" and "url"
       matrix: ${{ fromJson(needs.repos.outputs.repos) }}
     steps:
-    - uses: webfactory/ssh-agent@v0.9.1
+    # Mint a short-lived installation token from the "DUNE Mirrorer" GitHub App
+    # (app id 4076510 / client id Iv23liLgyeU7QoelDvvz). The app private key is
+    # stored in the DUNE_MIRRORER_CERT secret. The token is scoped to just the
+    # target mirror repository and replaces the old per-repo SSH deploy keys.
+    - name: Generate push token for ${{ matrix.module_name }}
+      id: app-token
+      uses: actions/create-github-app-token@v1
       with:
-        ssh-private-key: ${{ secrets[format('SSH_KEY_{0}', matrix.keyname )] }}
+        app-id: "4076510"
+        private-key: ${{ secrets.DUNE_MIRRORER_CERT }}
+        owner: dune-mirrors
+        repositories: ${{ matrix.module_name }}
     - name: Mirror ${{ matrix.module_name }}
       env:
         MODULE_NAME: ${{ matrix.module_name }}
         SOURCE_URL: ${{ matrix.url }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         set -euo pipefail
         trap 'echo "::error title=mirror failed::${MODULE_NAME}: failed during \"${phase:-unknown}\" phase"' ERR
 
+        target="https://github.com/dune-mirrors/${MODULE_NAME}.git"
         echo "=== Mirroring ${MODULE_NAME} ==="
         echo "source: ${SOURCE_URL}"
-        echo "target: git@github.com:dune-mirrors/${MODULE_NAME}.git"
+        echo "target: ${target}"
 
         phase=clone
         echo "::group::clone (mirror) ${SOURCE_URL}"
         git clone --mirror "${SOURCE_URL}" "${MODULE_NAME}"
         cd "${MODULE_NAME}"
-        git remote set-url --push origin "git@github.com:dune-mirrors/${MODULE_NAME}.git"
+        git remote set-url --push origin "${target}"
         git remote -v
         echo "::endgroup::"
 
@@ -79,7 +90,10 @@ jobs:
 
         phase=push
         echo "::group::push --mirror"
-        git push --mirror
+        # Supply the App token via an HTTP auth header so it is never written to
+        # .git/config or shown in the remote URL.
+        auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
+        git -c http.extraheader="AUTHORIZATION: basic ${auth}" push --mirror
         echo "::endgroup::"
 
         echo "✓ mirrored ${MODULE_NAME} (${branches} branches, ${tags} tags)"

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -36,14 +36,53 @@ jobs:
     - uses: webfactory/ssh-agent@v0.9.1
       with:
         ssh-private-key: ${{ secrets[format('SSH_KEY_{0}', matrix.keyname )] }}
-    - run: |
-        git clone --mirror ${{ matrix.url }} ${{ matrix.module_name }}
-        cd ${{ matrix.module_name }}
-        git remote set-url --push origin git@github.com:dune-mirrors/${{ matrix.module_name }}.git
+    - name: Mirror ${{ matrix.module_name }}
+      env:
+        MODULE_NAME: ${{ matrix.module_name }}
+        SOURCE_URL: ${{ matrix.url }}
+      run: |
+        set -euo pipefail
+        trap 'echo "::error title=mirror failed::${MODULE_NAME}: failed during \"${phase:-unknown}\" phase"' ERR
+
+        echo "=== Mirroring ${MODULE_NAME} ==="
+        echo "source: ${SOURCE_URL}"
+        echo "target: git@github.com:dune-mirrors/${MODULE_NAME}.git"
+
+        phase=clone
+        echo "::group::clone (mirror) ${SOURCE_URL}"
+        git clone --mirror "${SOURCE_URL}" "${MODULE_NAME}"
+        cd "${MODULE_NAME}"
+        git remote set-url --push origin "git@github.com:dune-mirrors/${MODULE_NAME}.git"
+        git remote -v
+        echo "::endgroup::"
+
+        phase=fetch
+        echo "::group::fetch -p origin"
         git fetch -p origin
-        # Exclude refs created by GitHub for pull request.
+        echo "::endgroup::"
+
+        phase=inspect
+        echo "::group::ref inventory"
+        total=$(git for-each-ref | wc -l)
+        branches=$(git for-each-ref refs/heads | wc -l)
+        tags=$(git for-each-ref refs/tags | wc -l)
+        mr=$(git for-each-ref refs/merge-requests | wc -l)
+        echo "total refs: ${total} | branches: ${branches} | tags: ${tags} | merge-request refs (to drop): ${mr}"
+        echo "::endgroup::"
+
+        phase=cleanup
+        echo "::group::drop GitLab merge-request refs"
+        # Exclude GitLab merge-request refs (refs/merge-requests/*); GitHub rejects them on push.
         git for-each-ref --format 'delete %(refname)' refs/merge-requests | git update-ref --stdin
+        echo "dropped ${mr} merge-request ref(s)"
+        echo "::endgroup::"
+
+        phase=push
+        echo "::group::push --mirror"
         git push --mirror
+        echo "::endgroup::"
+
+        echo "✓ mirrored ${MODULE_NAME} (${branches} branches, ${tags} tags)"
 
   mirror-success:
     runs-on: ubuntu-24.04

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -104,21 +104,38 @@ jobs:
   mirror-success:
     runs-on: ubuntu-24.04
     needs: mirror
-    # Only update the README on real mirror runs, not on pull requests.
-    if: github.event_name != 'pull_request'
+    # Always run so this gate reports an explicit pass/fail and is never left in a
+    # "skipped" state (which branch protection treats as not passed, e.g. after a
+    # partial "re-run failed jobs").
+    if: always()
     permissions:
       contents: write
     steps:
+    - name: Verify all mirror jobs succeeded
+      env:
+        MIRROR_RESULT: ${{ needs.mirror.result }}
+      run: |
+        echo "mirror jobs result: ${MIRROR_RESULT}"
+        if [ "${MIRROR_RESULT}" != "success" ]; then
+          echo "::error::one or more mirror jobs did not succeed (result: ${MIRROR_RESULT})"
+          exit 1
+        fi
+        echo "All mirror jobs completed successfully"
+    # Record the last successful mirror time in the README. Only on real mirror
+    # runs (not pull requests), and only reached when the gate above passed.
     - uses: actions/checkout@v6
+      if: github.event_name != 'pull_request'
       with:
         ref: main
     - name: Update last-updated timestamp in README
+      if: github.event_name != 'pull_request'
       run: |
         timestamp="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
         sed -i \
           "s|^Mirrors last updated at: .*|Mirrors last updated at: ${timestamp}|" \
           README.md
     - name: Commit and push if changed
+      if: github.event_name != 'pull_request'
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -34,14 +34,17 @@ jobs:
       matrix: ${{ fromJson(needs.repos.outputs.repos) }}
     steps:
     # Mint a short-lived installation token from the "DUNE Mirrorer" GitHub App
-    # (client id Iv23liLgyeU7QoelDvvz, app id 4076510). The app private key is
+    # (app id 4076510 / client id Iv23liLgyeU7QoelDvvz). The app private key is
     # stored in the DUNE_MIRRORER_CERT secret. The token is scoped to just the
     # target mirror repository and replaces the old per-repo SSH deploy keys.
+    # NB: app-id is used rather than the newer client-id because actionlint's
+    # bundled metadata does not yet recognise client-id; both are accepted by
+    # the action and app-id only emits a soft (non-fatal) deprecation warning.
     - name: Generate push token for ${{ matrix.module_name }}
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        client-id: "Iv23liLgyeU7QoelDvvz"
+        app-id: "4076510"
         private-key: ${{ secrets.DUNE_MIRRORER_CERT }}
         owner: dune-mirrors
         repositories: ${{ matrix.module_name }}

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     # Mint a short-lived installation token from the "DUNE Mirrorer" GitHub App
     # (app id 4076510 / client id Iv23liLgyeU7QoelDvvz). The app private key is
-    # stored in the DUNE_MIRRORER_CERT secret. The token is scoped to just the
+    # stored in the DUNE_MIRRORER_PRIVATE_KEY secret. The token is scoped to just the
     # target mirror repository and replaces the old per-repo SSH deploy keys.
     # NB: app-id is used rather than the newer client-id because actionlint's
     # bundled metadata does not yet recognise client-id; both are accepted by
@@ -45,7 +45,7 @@ jobs:
       uses: actions/create-github-app-token@v3
       with:
         app-id: "4076510"
-        private-key: ${{ secrets.DUNE_MIRRORER_CERT }}
+        private-key: ${{ secrets.DUNE_MIRRORER_PRIVATE_KEY }}
         owner: dune-mirrors
         repositories: ${{ matrix.module_name }}
     - name: Mirror ${{ matrix.module_name }}

--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -34,14 +34,14 @@ jobs:
       matrix: ${{ fromJson(needs.repos.outputs.repos) }}
     steps:
     # Mint a short-lived installation token from the "DUNE Mirrorer" GitHub App
-    # (app id 4076510 / client id Iv23liLgyeU7QoelDvvz). The app private key is
+    # (client id Iv23liLgyeU7QoelDvvz, app id 4076510). The app private key is
     # stored in the DUNE_MIRRORER_CERT secret. The token is scoped to just the
     # target mirror repository and replaces the old per-repo SSH deploy keys.
     - name: Generate push token for ${{ matrix.module_name }}
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: "4076510"
+        client-id: "Iv23liLgyeU7QoelDvvz"
         private-key: ${{ secrets.DUNE_MIRRORER_CERT }}
         owner: dune-mirrors
         repositories: ${{ matrix.module_name }}

--- a/README.md
+++ b/README.md
@@ -34,17 +34,25 @@ The mirroring process is implemented as a GitHub Actions workflow defined in `.g
 
 3. **Mirroring Process**:
    - For each repository in the matrix, a separate job runs in parallel
-   - The job sets up SSH authentication using repository-specific SSH keys stored as GitHub secrets
+   - The job mints a short-lived installation token from the **DUNE Mirrorer** GitHub App
+     (its private key is stored in the `DUNE_MIRRORER_CERT` secret), scoped to just the
+     target mirror repository
    - It clones the GitLab repository with `--mirror` option to get all branches and tags
    - Sets the push URL to the corresponding repository in the dune-mirrors GitHub organization
-   - Removes any GitHub-specific pull request references
-   - Pushes all branches and tags to GitHub with `--mirror` option
+   - Removes the GitLab merge-request references (which GitHub rejects on push)
+   - Pushes all branches and tags to GitHub with `--mirror` option, authenticating with the App token
+
+### Authentication
+
+Pushes to the `dune-mirrors` org are authenticated with the **DUNE Mirrorer** GitHub App
+rather than per-repository SSH deploy keys. The App must be installed on the organization
+with **Contents: write** permission and granted access to the mirror repositories. Only its
+private key (the `DUNE_MIRRORER_CERT` Actions secret) needs to be configured.
 
 ## Installation and Dependencies
 
 This project uses `pyproject.toml` for dependency management. The required dependencies are:
 - requests: For making HTTP requests to the GitHub API
-- pynacl: For encryption operations
 - python-dotenv: For loading environment variables from .env files
 
 ### Installing Dependencies
@@ -74,7 +82,8 @@ To run the scripts locally:
    GITHUB_TOKEN=your_github_token
    ```
 
-2. Run the infrastructure setup script:
+2. Run the infrastructure setup script (ensures each mirror repo exists in the org;
+   authentication for pushes is handled by the DUNE Mirrorer GitHub App):
    ```bash
    python infra_setup.py
    ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The mirroring process is implemented as a GitHub Actions workflow defined in `.g
 3. **Mirroring Process**:
    - For each repository in the matrix, a separate job runs in parallel
    - The job mints a short-lived installation token from the **DUNE Mirrorer** GitHub App
-     (its private key is stored in the `DUNE_MIRRORER_CERT` secret), scoped to just the
+     (its private key is stored in the `DUNE_MIRRORER_PRIVATE_KEY` secret), scoped to just the
      target mirror repository
    - It clones the GitLab repository with `--mirror` option to get all branches and tags
    - Sets the push URL to the corresponding repository in the dune-mirrors GitHub organization
@@ -47,7 +47,7 @@ The mirroring process is implemented as a GitHub Actions workflow defined in `.g
 Pushes to the `dune-mirrors` org are authenticated with the **DUNE Mirrorer** GitHub App
 rather than per-repository SSH deploy keys. The App must be installed on the organization
 with **Contents: write** permission and granted access to the mirror repositories. Only its
-private key (the `DUNE_MIRRORER_CERT` Actions secret) needs to be configured.
+private key (the `DUNE_MIRRORER_PRIVATE_KEY` Actions secret) needs to be configured.
 
 ## Installation and Dependencies
 

--- a/infra_setup.py
+++ b/infra_setup.py
@@ -14,6 +14,7 @@ from nacl import public
 HTTP_OK = 200
 HTTP_CREATED = 201
 HTTP_NO_CONTENT = 204
+HTTP_UNPROCESSABLE = 422
 
 # Load environment variables from .env file
 load_dotenv()
@@ -78,7 +79,10 @@ def generate_ssh_key(repo_name):
 
 
 def create_repo_if_not_exists(repo_name):
-    """Create a repository in the dune-mirrors organization if it doesn't exist"""
+    """Create a repository in the dune-mirrors organization if it doesn't exist.
+
+    Returns True if a new repository was created, False if it already existed.
+    """
     print(f"Checking if repository {repo_name} exists in {GITHUB_ORG} organization...")
 
     # Check if repository exists
@@ -86,7 +90,7 @@ def create_repo_if_not_exists(repo_name):
 
     if response.status_code == HTTP_OK:
         print(f"Repository {repo_name} already exists.")
-        return
+        return False
 
     print(f"Creating repository {repo_name} in {GITHUB_ORG} organization...")
 
@@ -105,13 +109,14 @@ def create_repo_if_not_exists(repo_name):
     )
 
     if response.status_code != HTTP_CREATED:
-        raise Exception(f"Failed to create repository: {response.text}")
+        raise Exception(f"Failed to create repository (HTTP {response.status_code}): {response.text}")
 
     print(f"Repository {repo_name} created successfully.")
+    return True
 
 
 def add_deploy_key_to_repo(repo_name, public_key):
-    """Add deploy key to a repository"""
+    """Add deploy key to a repository (idempotent across re-runs)."""
     print(f"Adding deploy key to {repo_name}...")
 
     response = requests.post(
@@ -120,10 +125,17 @@ def add_deploy_key_to_repo(repo_name, public_key):
         json={"title": "Mirror Deploy Key", "key": public_key, "read_only": False},
     )
 
-    if response.status_code != HTTP_CREATED:
-        raise Exception(f"Failed to add deploy key to repository: {response.text}")
+    if response.status_code == HTTP_CREATED:
+        print(f"Deploy key added to {repo_name} successfully.")
+        return
 
-    print(f"Deploy key added to {repo_name} successfully.")
+    # GitHub returns 422 when the key (or its title) already exists. Treat that as a
+    # no-op so re-running setup does not crash on an already-provisioned repo.
+    if response.status_code == HTTP_UNPROCESSABLE and "already" in response.text.lower():
+        print(f"Deploy key already present on {repo_name}, skipping.")
+        return
+
+    raise Exception(f"Failed to add deploy key (HTTP {response.status_code}): {response.text}")
 
 
 def add_secret_to_mirrorer_repo(secret_name, secret_value):
@@ -137,7 +149,7 @@ def add_secret_to_mirrorer_repo(secret_name, secret_value):
     )
 
     if response.status_code != HTTP_OK:
-        raise Exception(f"Failed to get public key for secrets: {response.text}")
+        raise Exception(f"Failed to get public key for secrets (HTTP {response.status_code}): {response.text}")
 
     public_key_data = response.json()
     public_key = public_key_data["key"]
@@ -161,7 +173,7 @@ def add_secret_to_mirrorer_repo(secret_name, secret_value):
     )
 
     if response.status_code not in (HTTP_CREATED, HTTP_NO_CONTENT):
-        raise Exception(f"Failed to add secret to repository: {response.text}")
+        raise Exception(f"Failed to add secret to repository (HTTP {response.status_code}): {response.text}")
 
     print(f"Secret {secret_name} added to {CURRENT_REPO} successfully.")
 
@@ -172,15 +184,22 @@ def main():
 
     # Load repository configuration
     repos = load_repos()
+    total = len(repos)
+    created = 0
+    existing = 0
+    secrets_written = 0
 
-    for repo_name, _repo_url in repos.items():
-        print(f"\nProcessing repository: {repo_name}")
+    for index, (repo_name, _repo_url) in enumerate(repos.items(), start=1):
+        print(f"\n[{index}/{total}] Processing repository: {repo_name}")
 
         # Generate SSH key pair
         private_key, public_key = generate_ssh_key(repo_name)
 
         # Create repository if it doesn't exist
-        create_repo_if_not_exists(repo_name)
+        if create_repo_if_not_exists(repo_name):
+            created += 1
+        else:
+            existing += 1
 
         # Add deploy key to repository
         add_deploy_key_to_repo(repo_name, public_key)
@@ -189,8 +208,14 @@ def main():
         # Replace hyphens with underscores in the repository name for the secret name
         secret_name = f"SSH_KEY_{repo_name.replace('-', '_')}"
         add_secret_to_mirrorer_repo(secret_name, private_key)
+        secrets_written += 1
 
     print("\nInfrastructure setup completed successfully.")
+    print(
+        f"Summary: {total} repo(s) processed "
+        f"({created} created, {existing} already existed), "
+        f"{secrets_written} secret(s) written.",
+    )
 
 
 if __name__ == "__main__":

--- a/infra_setup.py
+++ b/infra_setup.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
-import base64
+"""One-off infrastructure setup for the GitHub mirrors.
+
+Authentication for pushing to the mirrors is handled at run time by the
+"DUNE Mirrorer" GitHub App (see .github/workflows/mirrorer.yml), so this script
+only has to make sure each configured mirror repository exists in the
+dune-mirrors organization. The GitHub App itself must be installed on the
+organization with "Contents: write" permission and granted access to these
+repositories.
+"""
+
 import json
 import os
-import subprocess
-import tempfile
 from pathlib import Path
 
 import requests
 from dotenv import load_dotenv
-from nacl import public
 
 # HTTP status codes
 HTTP_OK = 200
 HTTP_CREATED = 201
-HTTP_NO_CONTENT = 204
-HTTP_UNPROCESSABLE = 422
 
 # Load environment variables from .env file
 load_dotenv()
@@ -27,7 +31,6 @@ if not GITHUB_TOKEN:
 # GitHub API base URL
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_ORG = "dune-mirrors"
-CURRENT_REPO = "dune-mirrors/mirrorer"
 
 # Headers for GitHub API requests
 headers = {
@@ -40,42 +43,6 @@ def load_repos():
     """Load repository configuration from repos.json"""
     with Path("repos.json").open() as f:
         return json.load(f)
-
-
-def generate_ssh_key(repo_name):
-    """Generate SSH key pair for a repository"""
-    print(f"Generating SSH key for {repo_name}...")
-
-    # Create a temporary directory to store the keys
-    with tempfile.TemporaryDirectory() as temp_dir:
-        key_file = Path(temp_dir) / "id_rsa"
-
-        # Generate SSH key pair without passphrase
-        subprocess.run(
-            [
-                "ssh-keygen",
-                "-t",
-                "rsa",
-                "-b",
-                "4096",
-                "-C",
-                f"deploy-key-{repo_name}@dune-mirrors",
-                "-f",
-                str(key_file),
-                "-N",
-                "",
-            ],
-            check=True,
-        )
-
-        # Read the private and public keys
-        with key_file.open() as f:
-            private_key = f.read()
-
-        with Path(f"{key_file}.pub").open() as f:
-            public_key = f.read()
-
-        return private_key, public_key
 
 
 def create_repo_if_not_exists(repo_name):
@@ -115,69 +82,6 @@ def create_repo_if_not_exists(repo_name):
     return True
 
 
-def add_deploy_key_to_repo(repo_name, public_key):
-    """Add deploy key to a repository (idempotent across re-runs)."""
-    print(f"Adding deploy key to {repo_name}...")
-
-    response = requests.post(
-        f"{GITHUB_API_URL}/repos/{GITHUB_ORG}/{repo_name}/keys",
-        headers=headers,
-        json={"title": "Mirror Deploy Key", "key": public_key, "read_only": False},
-    )
-
-    if response.status_code == HTTP_CREATED:
-        print(f"Deploy key added to {repo_name} successfully.")
-        return
-
-    # GitHub returns 422 when the key (or its title) already exists. Treat that as a
-    # no-op so re-running setup does not crash on an already-provisioned repo.
-    if response.status_code == HTTP_UNPROCESSABLE and "already" in response.text.lower():
-        print(f"Deploy key already present on {repo_name}, skipping.")
-        return
-
-    raise Exception(f"Failed to add deploy key (HTTP {response.status_code}): {response.text}")
-
-
-def add_secret_to_mirrorer_repo(secret_name, secret_value):
-    """Add a secret to the dune-mirrors/mirrorer repository"""
-    print(f"Adding secret {secret_name} to {CURRENT_REPO} repository...")
-
-    # Get the repository's public key for secret encryption
-    response = requests.get(
-        f"{GITHUB_API_URL}/repos/{CURRENT_REPO}/actions/secrets/public-key",
-        headers=headers,
-    )
-
-    if response.status_code != HTTP_OK:
-        raise Exception(f"Failed to get public key for secrets (HTTP {response.status_code}): {response.text}")
-
-    public_key_data = response.json()
-    public_key = public_key_data["key"]
-    public_key_id = public_key_data["key_id"]
-
-    # Encrypt the secret value using PyNaCl
-    def encrypt(public_key: str, secret_value: str) -> str:
-        """Encrypt a string using the provided public key."""
-        public_key_bytes = public.PublicKey(base64.b64decode(public_key))
-        sealed_box = public.SealedBox(public_key_bytes)
-        encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
-        return base64.b64encode(encrypted).decode("utf-8")
-
-    encrypted_value = encrypt(public_key, secret_value)
-
-    # Send the encrypted secret to GitHub
-    response = requests.put(
-        f"{GITHUB_API_URL}/repos/{CURRENT_REPO}/actions/secrets/{secret_name}",
-        headers=headers,
-        json={"encrypted_value": encrypted_value, "key_id": public_key_id},
-    )
-
-    if response.status_code not in (HTTP_CREATED, HTTP_NO_CONTENT):
-        raise Exception(f"Failed to add secret to repository (HTTP {response.status_code}): {response.text}")
-
-    print(f"Secret {secret_name} added to {CURRENT_REPO} successfully.")
-
-
 def main():
     """Main function"""
     print("Starting infrastructure setup...")
@@ -187,13 +91,9 @@ def main():
     total = len(repos)
     created = 0
     existing = 0
-    secrets_written = 0
 
-    for index, (repo_name, _repo_url) in enumerate(repos.items(), start=1):
+    for index, repo_name in enumerate(repos, start=1):
         print(f"\n[{index}/{total}] Processing repository: {repo_name}")
-
-        # Generate SSH key pair
-        private_key, public_key = generate_ssh_key(repo_name)
 
         # Create repository if it doesn't exist
         if create_repo_if_not_exists(repo_name):
@@ -201,20 +101,12 @@ def main():
         else:
             existing += 1
 
-        # Add deploy key to repository
-        add_deploy_key_to_repo(repo_name, public_key)
-
-        # Add private key as a secret to the mirrorer repository
-        # Replace hyphens with underscores in the repository name for the secret name
-        secret_name = f"SSH_KEY_{repo_name.replace('-', '_')}"
-        add_secret_to_mirrorer_repo(secret_name, private_key)
-        secrets_written += 1
-
     print("\nInfrastructure setup completed successfully.")
+    print(f"Summary: {total} repo(s) processed ({created} created, {existing} already existed).")
     print(
-        f"Summary: {total} repo(s) processed "
-        f"({created} created, {existing} already existed), "
-        f"{secrets_written} secret(s) written.",
+        "\nReminder: pushing is handled by the 'DUNE Mirrorer' GitHub App. Ensure the app is "
+        "installed on the dune-mirrors org with 'Contents: write' permission and granted access "
+        "to the repositories above.",
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.13"
 license = {text = "MIT"}
 dependencies = [
     "requests",
-    "pynacl",
     "python-dotenv",
 ]
 

--- a/repos_to_matrix.py
+++ b/repos_to_matrix.py
@@ -1,20 +1,66 @@
 import json
+import sys
 from pathlib import Path
 
-with Path("repos.json").open() as f:
-    repos = json.load(f)
-
-print('{"include" : [')
-items = list(repos.items())
+REPOS_FILE = Path("repos.json")
 
 
-def _println(repo, url):
-    slug = repo.replace("-", "_")
-    print(f'  {{ "module_name": "{repo}", "url": "{url}", "keyname": "{slug}"}} ', end="")
+def fail(message):
+    """Print an error to stderr and exit non-zero."""
+    print(f"repos_to_matrix: error: {message}", file=sys.stderr)
+    sys.exit(1)
 
 
-for repo, url in items[:-1]:
-    _println(repo, url)
-    print(",", end="")
-_println(items[-1][0], items[-1][1])
-print("]}")
+def load_repos():
+    """Load and validate the repository configuration from repos.json."""
+    if not REPOS_FILE.exists():
+        fail(f"{REPOS_FILE} not found (run from the repository root)")
+
+    try:
+        with REPOS_FILE.open() as f:
+            repos = json.load(f)
+    except json.JSONDecodeError as exc:
+        fail(f"{REPOS_FILE} is not valid JSON: {exc}")
+
+    if not isinstance(repos, dict) or not repos:
+        fail(f"{REPOS_FILE} must be a non-empty JSON object mapping name -> URL")
+
+    for name, url in repos.items():
+        if not isinstance(url, str) or not url.strip():
+            fail(f"repository '{name}' has an empty or non-string URL")
+        if not url.startswith(("http://", "https://", "git@")):
+            fail(f"repository '{name}' has a URL that does not look like a git remote: {url!r}")
+
+    return repos
+
+
+def build_matrix(repos):
+    """Build the GitHub Actions matrix include list from the repo config."""
+    return {
+        "include": [
+            {
+                "module_name": repo,
+                "url": url,
+                # keyname is used to look up the per-repo SSH secret SSH_KEY_<keyname>;
+                # GitHub secret names cannot contain hyphens, so map them to underscores.
+                "keyname": repo.replace("-", "_"),
+            }
+            for repo, url in repos.items()
+        ]
+    }
+
+
+def main():
+    repos = load_repos()
+    matrix = build_matrix(repos)
+
+    # stdout is captured into GITHUB_OUTPUT by the workflow, so it must contain
+    # ONLY the matrix JSON. All diagnostics go to stderr.
+    names = ", ".join(repos)
+    print(f"repos_to_matrix: built matrix for {len(repos)} repos: {names}", file=sys.stderr)
+
+    print(json.dumps(matrix))
+
+
+if __name__ == "__main__":
+    main()

--- a/repos_to_matrix.py
+++ b/repos_to_matrix.py
@@ -36,18 +36,7 @@ def load_repos():
 
 def build_matrix(repos):
     """Build the GitHub Actions matrix include list from the repo config."""
-    return {
-        "include": [
-            {
-                "module_name": repo,
-                "url": url,
-                # keyname is used to look up the per-repo SSH secret SSH_KEY_<keyname>;
-                # GitHub secret names cannot contain hyphens, so map them to underscores.
-                "keyname": repo.replace("-", "_"),
-            }
-            for repo, url in repos.items()
-        ]
-    }
+    return {"include": [{"module_name": repo, "url": url} for repo, url in repos.items()]}
 
 
 def main():


### PR DESCRIPTION
## Summary

Reviews the mirror workflow/scripts, adds debug output, and — the main change — **replaces the broken per-repo SSH deploy-key auth with the DUNE Mirrorer GitHub App**.

### Why
Mirroring had been silently broken: the last successful run was the scheduled run on **2025-06-11**, the cron then auto-disabled (60-day inactivity), and every run on 2026-06-17 — including `workflow_dispatch` and `push` on `main` — failed at `git push --mirror` with `Permission denied (publickey)`. Clones from GitLab worked fine (all 14 source repos verified reachable), so only the push auth to the GitHub mirrors was dead. The new debug output pinpointed the failing phase exactly.

## Changes

### Auth: GitHub App instead of SSH deploy keys
- Each `mirror` job mints a short-lived installation token from the **DUNE Mirrorer** GitHub App (app id `4076510`) via `actions/create-github-app-token@v1`, scoped to just its target repository.
- The push authenticates over HTTPS using the token in an `http.extraheader`, so it's never written to `.git/config` or printed.
- Only the App private key (`DUNE_MIRRORER_CERT` secret) needs configuring — the old `SSH_KEY_*` per-repo secrets and deploy keys are no longer used.
- `repos_to_matrix.py` drops the now-unused `keyname` matrix field.
- `infra_setup.py` is slimmed to repository creation only (SSH keygen, deploy keys, and per-repo secret upload removed); `pynacl` dependency dropped.
- README updated to document the new auth model.

### Debug output (from the original review)
- Mirror job: `set -euo pipefail`, collapsible `::group::` sections per phase, a ref inventory (branches/tags/merge-request refs), and an `ERR` trap that emits a `::error::` naming the failing repo + phase.
- `repos_to_matrix.py`: validates `repos.json`, builds the matrix with `json.dumps`, logs a summary to **stderr** (stdout stays pure JSON for `GITHUB_OUTPUT`).
- `infra_setup.py`: `[i/total]` progress, final summary, HTTP status in error messages.

### Review fixes
- Corrected the misleading comment: `refs/merge-requests` are **GitLab** merge-request refs.

## Notes / follow-ups
- The App must be installed on the `dune-mirrors` org with **Contents: write** and granted access to the mirror repos for the push to succeed.
- The auto-disabled daily **cron** needs re-enabling in the Actions tab once a green run lands.

## Verification
- `python repos_to_matrix.py | python -m json.tool` → valid JSON (no `keyname`); summary on stderr only.
- `infra_setup.py` compiles; `ruff`, `ruff format --check`, and `actionlint -shellcheck=shellcheck` all clean.
- Mirror shell logic dry-run locally against a repo (clone + ref inventory + merge-request delete, no push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sbAxSLwzBUKbFDEiR7gsp