### PR TITLE
Push README timestamp update via App token in its own job

### DIFF
--- a/.github/workflows/mirrorer.yml
+++ b/.github/workflows/mirrorer.yml
@@ -108,8 +108,6 @@ jobs:
     # "skipped" state (which branch protection treats as not passed, e.g. after a
     # partial "re-run failed jobs").
     if: always()
-    permissions:
-      contents: write
     steps:
     - name: Verify all mirror jobs succeeded
       env:
@@ -121,21 +119,39 @@ jobs:
           exit 1
         fi
         echo "All mirror jobs completed successfully"
-    # Record the last successful mirror time in the README. Only on real mirror
-    # runs (not pull requests), and only reached when the gate above passed.
+
+  update-readme:
+    runs-on: ubuntu-24.04
+    needs: mirror
+    # Record the last successful mirror time in the README on main. Only on real
+    # mirror runs (not pull requests); `needs: mirror` ensures it runs only when
+    # every mirror job succeeded. Kept separate from the mirror-success gate so a
+    # README push problem never makes the required check fail.
+    if: github.event_name != 'pull_request'
+    steps:
+    # main is a protected branch (requires PRs), so the default GITHUB_TOKEN
+    # cannot push to it. Push with a DUNE Mirrorer App token instead; the App
+    # must be granted access to the mirrorer repo and added to the branch
+    # protection "allow specified actors to bypass required pull requests" list.
+    - name: Generate token to update the README
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: "4076510"
+        private-key: ${{ secrets.DUNE_MIRRORER_PRIVATE_KEY }}
+        owner: dune-mirrors
+        repositories: mirrorer
     - uses: actions/checkout@v6
-      if: github.event_name != 'pull_request'
       with:
         ref: main
+        token: ${{ steps.app-token.outputs.token }}
     - name: Update last-updated timestamp in README
-      if: github.event_name != 'pull_request'
       run: |
         timestamp="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
         sed -i \
           "s|^Mirrors last updated at: .*|Mirrors last updated at: ${timestamp}|" \
           README.md
     - name: Commit and push if changed
-      if: github.event_name != 'pull_request'
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## Problem

The post-merge run on `main` failed ([run 27687591561](https://github.com/dune-mirrors/mirrorer/actions/runs/27687591561)). All mirroring succeeded (14/14 `mirror` jobs + `repos`); the only failure was the README "last-updated" auto-commit step pushing to `main`:

```
remote: - Changes must be made through a pull request.
! [remote rejected] main -> main (protected branch hook declined)
```

`main` is protected (requires PRs), so the default `GITHUB_TOKEN` can't push to it. Because that push lived inside the combined `mirror-success` job, it also turned the **required** gate red for a reason unrelated to mirroring.

## Fix

Split the job in two:
- **`mirror-success`** — unchanged behaviour, purely the always-run pass/fail gate over the matrix (`needs: mirror`, `if: always()`). No longer coupled to the README push.
- **`update-readme`** (new) — runs only on non-PR events and only when all `mirror` jobs succeeded (`needs: mirror`). It mints a **DUNE Mirrorer App token** (`actions/create-github-app-token@v3`, scoped to the `mirrorer` repo), checks out `main` with that token, updates the timestamp, and pushes.

## Required one-time config (you)

For the push to be accepted:
1. The DUNE Mirrorer App must have **access to the `dune-mirrors/mirrorer` repo** (not just the 14 mirror repos) with **Contents: write**.
2. Add the App to `main`'s branch protection **"Allow specified actors to bypass required pull requests"** list.

Without the bypass entry, the `update-readme` push will still be rejected — but it can no longer fail the required `mirror-success` check.

## Verification
- `actionlint -shellcheck=shellcheck` clean.
- On a PR, `update-readme` is skipped (no push); `mirror-success` runs as the gate. On `main`, after the bypass config, `update-readme` should push the timestamp commit (`[skip ci]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sbAxSLwzBUKbFDEiR7gsp

---
_Generated by [Claude Code](https://claude.ai/code/session_018sbAxSLwzBUKbFDEiR7gsp)_